### PR TITLE
Make CLAWDBOT_SERVICE optional (avoid false DEGRADED)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Raspberry Pi 上で動く OpenClaw/Clawdbot の **運用(ops)** 用リポジト�
 
 現在の実装は以下を収集します：
 - ホスト情報 (uptime / load / memory / IP)
-- systemd サービス状態 (`CLAWDBOT_SERVICE` で指定)
+- （任意）systemd サービス状態（`CLAWDBOT_SERVICE` を設定した場合）
 
 ## Quick start (dev)
 
@@ -34,9 +34,15 @@ npm start
 
 - `PORT` (default: 8080)
 - `HOST` (default: 0.0.0.0)
-- `CLAWDBOT_SERVICE` (default: `clawdbot-gateway`)
+- `CLAWDBOT_SERVICE` (optional)
 
-> `CLAWDBOT_SERVICE` は、raspi 側の systemd unit 名に合わせてください。
+> `CLAWDBOT_SERVICE` を設定すると systemd unit の `is-active` を表示し、inactive の場合は Health を `DEGRADED` にします。
+> 例：
+> 
+> ```bash
+> systemctl list-unit-files | grep -i claw
+> CLAWDBOT_SERVICE=<unit名> npm run dev
+> ```
 
 ## Security note
 

--- a/systemd/raspi-openclaw-ops.service
+++ b/systemd/raspi-openclaw-ops.service
@@ -5,21 +5,24 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=/opt/raspi-clawdbot-ops
-ExecStart=/usr/bin/node /opt/raspi-clawdbot-ops/dist/server.js
+WorkingDirectory=/opt/raspi-openclaw-ops
+ExecStart=/usr/bin/node /opt/raspi-openclaw-ops/dist/server.js
 Restart=always
 RestartSec=2
 Environment=PORT=8080
 Environment=HOST=0.0.0.0
-# Change to your actual unit name
-Environment=CLAWDBOT_SERVICE=clawdbot-gateway
+# Change to your actual unit name (optional)
+# If unset, service health is not checked.
+# Environment=CLAWDBOT_SERVICE=clawdbot-gateway
+
+Environment=CLAWDBOT_SERVICE=
 
 # Hardening (optional)
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/raspi-clawdbot-ops
+ReadWritePaths=/opt/raspi-openclaw-ops
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Why
Quickstart だけで起動すると `CLAWDBOT_SERVICE` の unit 名が環境と一致せず、Health が意図せず `DEGRADED` になるケースがあったため。

## What
- `CLAWDBOT_SERVICE` を **optional** に変更（未設定なら service 健康チェックをスキップ）
- UI でも未設定時は "not configured" と表示
- README に unit 名の探し方と設定例を追記
- systemd unit の `/opt/` パスを rename に合わせて修正

## How to test
- `npm run dev` で起動（service未設定なら OK）
- `CLAWDBOT_SERVICE=<unit名> npm run dev` で起動（active/inactive の表示確認）
