### PR TITLE
Add process-based health check (pgrep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ npm start
 - `PORT` (default: 8080)
 - `HOST` (default: 0.0.0.0)
 - `CLAWDBOT_SERVICE` (optional)
+- `CLAWDBOT_PROCESS_PATTERN` (optional)
 
 > `CLAWDBOT_SERVICE` を設定すると systemd unit の `is-active` を表示し、inactive の場合は Health を `DEGRADED` にします。
-> 例：
-> 
+> systemd 管理していない場合は `CLAWDBOT_PROCESS_PATTERN` を設定して `pgrep -f` でプロセス存在チェックします。
+>
+> 例（process check / 例: `clawdbot-gateway` が見えているケース）:
+>
 > ```bash
-> systemctl list-unit-files | grep -i claw
-> CLAWDBOT_SERVICE=<unit名> npm run dev
+> CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway npm run dev
 > ```
 
 ## Security note

--- a/systemd/raspi-openclaw-ops.service
+++ b/systemd/raspi-openclaw-ops.service
@@ -11,11 +11,15 @@ Restart=always
 RestartSec=2
 Environment=PORT=8080
 Environment=HOST=0.0.0.0
-# Change to your actual unit name (optional)
-# If unset, service health is not checked.
+# Health check (optional)
+# Use ONE of the following:
+# 1) systemd unit check
 # Environment=CLAWDBOT_SERVICE=clawdbot-gateway
+# 2) process existence check (pgrep -f)
+# Environment=CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway
 
 Environment=CLAWDBOT_SERVICE=
+Environment=CLAWDBOT_PROCESS_PATTERN=
 
 # Hardening (optional)
 NoNewPrivileges=true


### PR DESCRIPTION
## Context
`systemctl list-unit-files | grep -i claw` が何も返らず、Clawdbot が systemd 管理されていない環境では `CLAWDBOT_SERVICE` チェックが使えない。

`ps` では `clawdbot` / `clawdbot-gateway` プロセスが存在しているため、**プロセス存在チェック**を提供する。

## Changes
- Add optional process health check via `pgrep -f`
  - env: `CLAWDBOT_PROCESS_PATTERN`
  - if configured and no match → Health becomes `DEGRADED`
- UI card now shows either:
  - systemd unit state (if `CLAWDBOT_SERVICE` set)
  - process match count (if `CLAWDBOT_PROCESS_PATTERN` set)
  - or `not configured`
- Update README + systemd unit template

## How to test
```bash
npm run dev
# process check
CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway npm run dev
```
