### PR TITLE
systemd セットアップ手順を追加（起動時に自動起動）

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,14 @@ npm run dev
 
 ## Run (prod)
 
+### Option A: systemd (recommended)
+
+See: `docs/SETUP_SYSTEMD.md`
+
+### Option B: manual
+
 ```bash
-npm ci
+npm ci --include=dev
 npm run build
 npm start
 ```

--- a/docs/SETUP_SYSTEMD.md
+++ b/docs/SETUP_SYSTEMD.md
@@ -1,0 +1,68 @@
+# Setup: run raspi-openclaw-ops with systemd
+
+This project includes a sample unit file:
+- `systemd/raspi-openclaw-ops.service`
+
+## 1) Prepare directory
+
+We assume you deploy to:
+- `/opt/raspi-openclaw-ops`
+
+Example:
+
+```bash
+sudo mkdir -p /opt/raspi-openclaw-ops
+sudo chown -R $USER:$USER /opt/raspi-openclaw-ops
+```
+
+## 2) Install dependencies + build
+
+```bash
+cd /opt/raspi-openclaw-ops
+npm ci --include=dev
+npm run build
+```
+
+## 3) Install systemd unit
+
+```bash
+sudo cp systemd/raspi-openclaw-ops.service /etc/systemd/system/raspi-openclaw-ops.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now raspi-openclaw-ops
+```
+
+Check status:
+
+```bash
+systemctl status raspi-openclaw-ops
+journalctl -u raspi-openclaw-ops -f
+```
+
+## 4) Configure Clawdbot health check (optional)
+
+If Clawdbot is **not** managed by systemd, use process check:
+
+```bash
+sudo systemctl edit raspi-openclaw-ops
+```
+
+Add:
+
+```ini
+[Service]
+Environment=CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway
+```
+
+Reload:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart raspi-openclaw-ops
+```
+
+If Clawdbot is managed by systemd, you can instead set:
+
+```ini
+[Service]
+Environment=CLAWDBOT_SERVICE=<unit-name>
+```

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_DIR=${APP_DIR:-/opt/raspi-openclaw-ops}
+SERVICE_NAME=${SERVICE_NAME:-raspi-openclaw-ops}
+
+if [[ $EUID -eq 0 ]]; then
+  echo "Do not run as root. Run as a normal user with sudo available." >&2
+  exit 1
+fi
+
+echo "==> Installing to: ${APP_DIR}" >&2
+sudo mkdir -p "${APP_DIR}"
+sudo chown -R "$USER:$USER" "${APP_DIR}"
+
+echo "==> Syncing files" >&2
+rsync -a --delete \
+  --exclude node_modules \
+  --exclude dist \
+  --exclude .git \
+  ./ "${APP_DIR}/"
+
+echo "==> Installing dependencies & building" >&2
+cd "${APP_DIR}"
+npm ci --include=dev
+npm run build
+
+echo "==> Installing systemd unit" >&2
+sudo cp "${APP_DIR}/systemd/${SERVICE_NAME}.service" "/etc/systemd/system/${SERVICE_NAME}.service"
+sudo systemctl daemon-reload
+sudo systemctl enable --now "${SERVICE_NAME}"
+
+echo "==> Done" >&2
+echo "- Status: systemctl status ${SERVICE_NAME}" >&2
+echo "- Logs:   journalctl -u ${SERVICE_NAME} -f" >&2


### PR DESCRIPTION
## 目的
Raspberry Pi 起動時に `raspi-openclaw-ops` が自動で起動するよう、systemd でのセットアップ手順を追加します。

## 変更内容
- `docs/SETUP_SYSTEMD.md` を追加（systemd セットアップ手順）
- `scripts/install-systemd.sh` を追加（/opt 配備→依存導入→ビルド→unit配置→enable までを自動化）
- README から systemd セットアップ手順へリンク

## 補足
- このPRは **status server（raspi-openclaw-ops）を systemd 管理**するためのものです。
- Clawdbot 本体を systemd 管理していない場合でも、ヘルスチェックは `CLAWDBOT_PROCESS_PATTERN` で有効化できます。

## 動作確認
- `scripts/install-systemd.sh` を実行
- `systemctl status raspi-openclaw-ops`
- `journalctl -u raspi-openclaw-ops -f`
