### PR TITLE
ヘルスチェック表示の改善（clawdbot / clawdbot-gateway を監視）

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ npm start
 - `PORT` (default: 8080)
 - `HOST` (default: 0.0.0.0)
 - `CLAWDBOT_SERVICE` (optional)
-- `CLAWDBOT_PROCESS_PATTERN` (optional)
+- `CLAWDBOT_PROCESS_PATTERNS` (optional, comma-separated)
 
 > `CLAWDBOT_SERVICE` を設定すると systemd unit の `is-active` を表示し、inactive の場合は Health を `DEGRADED` にします。
-> systemd 管理していない場合は `CLAWDBOT_PROCESS_PATTERN` を設定して `pgrep -f` でプロセス存在チェックします。
+> systemd 管理していない場合は `CLAWDBOT_PROCESS_PATTERNS` を設定して `pgrep -f` でプロセス存在チェックします。
 >
-> 例（process check / 例: `clawdbot-gateway` が見えているケース）:
+> 例（process check / `clawdbot` と `clawdbot-gateway` を監視）:
 >
 > ```bash
-> CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway npm run dev
+> CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot npm run dev
 > ```
 
 ## Security note

--- a/systemd/raspi-openclaw-ops.service
+++ b/systemd/raspi-openclaw-ops.service
@@ -16,10 +16,10 @@ Environment=HOST=0.0.0.0
 # 1) systemd unit check
 # Environment=CLAWDBOT_SERVICE=clawdbot-gateway
 # 2) process existence check (pgrep -f)
-# Environment=CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway
+# Environment=CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
 
 Environment=CLAWDBOT_SERVICE=
-Environment=CLAWDBOT_PROCESS_PATTERN=
+Environment=CLAWDBOT_PROCESS_PATTERNS=
 
 # Hardening (optional)
 NoNewPrivileges=true


### PR DESCRIPTION
## 背景
現状のヘルスチェック表示が `pgrep -f ... → 1` のように実装寄りで、人間が見たときに分かりにくい。
また、監視対象を `clawdbot-gateway` だけでなく `clawdbot` も含めたい。

## 変更内容
- `CLAWDBOT_PROCESS_PATTERNS`（カンマ区切り）を追加
  - 例: `clawdbot-gateway,clawdbot`
- UIの表示を「RUNNING / NOT RUNNING」中心に変更
  - 補助情報として match数を表示
- README / systemd unit テンプレも `CLAWDBOT_PROCESS_PATTERNS` に合わせて更新

## 動作確認
```bash
CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot npm run dev
```
