### PR TITLE
install-systemd.sh で systemd override（drop-in）も自動生成

### DIFF
--- a/docs/SETUP_SYSTEMD.md
+++ b/docs/SETUP_SYSTEMD.md
@@ -40,6 +40,16 @@ journalctl -u raspi-openclaw-ops -f
 
 ## 4) Configure Clawdbot health check (optional)
 
+### Option A: set overrides via install script (recommended)
+
+You can pass env vars when running the installer:
+
+```bash
+CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot ./scripts/install-systemd.sh
+```
+
+### Option B: set a systemd drop-in manually
+
 If Clawdbot is **not** managed by systemd, use process check:
 
 ```bash
@@ -50,7 +60,7 @@ Add:
 
 ```ini
 [Service]
-Environment=CLAWDBOT_PROCESS_PATTERN=clawdbot-gateway
+Environment=CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
 ```
 
 Reload:

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 APP_DIR=${APP_DIR:-/opt/raspi-openclaw-ops}
 SERVICE_NAME=${SERVICE_NAME:-raspi-openclaw-ops}
 
+# Optional overrides for /etc/systemd/system/<service>.service.d/override.conf
+PORT=${PORT:-}
+HOST=${HOST:-}
+CLAWDBOT_SERVICE=${CLAWDBOT_SERVICE:-}
+CLAWDBOT_PROCESS_PATTERNS=${CLAWDBOT_PROCESS_PATTERNS:-}
+
 if [[ $EUID -eq 0 ]]; then
   echo "Do not run as root. Run as a normal user with sudo available." >&2
   exit 1
@@ -27,6 +33,28 @@ npm run build
 
 echo "==> Installing systemd unit" >&2
 sudo cp "${APP_DIR}/systemd/${SERVICE_NAME}.service" "/etc/systemd/system/${SERVICE_NAME}.service"
+
+# Create systemd drop-in overrides if any env vars are provided.
+OVERRIDE_DIR="/etc/systemd/system/${SERVICE_NAME}.service.d"
+OVERRIDE_FILE="${OVERRIDE_DIR}/override.conf"
+
+if [[ -n "${PORT}" || -n "${HOST}" || -n "${CLAWDBOT_SERVICE}" || -n "${CLAWDBOT_PROCESS_PATTERNS}" ]]; then
+  echo "==> Writing systemd override: ${OVERRIDE_FILE}" >&2
+  sudo mkdir -p "${OVERRIDE_DIR}"
+
+  tmpfile=$(mktemp)
+  {
+    echo "[Service]"
+    [[ -n "${PORT}" ]] && echo "Environment=PORT=${PORT}"
+    [[ -n "${HOST}" ]] && echo "Environment=HOST=${HOST}"
+    [[ -n "${CLAWDBOT_SERVICE}" ]] && echo "Environment=CLAWDBOT_SERVICE=${CLAWDBOT_SERVICE}"
+    [[ -n "${CLAWDBOT_PROCESS_PATTERNS}" ]] && echo "Environment=CLAWDBOT_PROCESS_PATTERNS=${CLAWDBOT_PROCESS_PATTERNS}"
+  } >"${tmpfile}"
+
+  sudo cp "${tmpfile}" "${OVERRIDE_FILE}"
+  rm -f "${tmpfile}"
+fi
+
 sudo systemctl daemon-reload
 sudo systemctl enable --now "${SERVICE_NAME}"
 


### PR DESCRIPTION
## 目的
`./scripts/install-systemd.sh` の実行だけで、systemd の override（drop-in）も自動生成できるようにする。

これにより、手動で `/etc/systemd/system/raspi-openclaw-ops.service` を編集せずに
`CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot` 相当の設定を反映できる。

## 変更内容
- `scripts/install-systemd.sh`
  - 以下の環境変数が指定されている場合、`/etc/systemd/system/<service>.service.d/override.conf` を自動生成
    - `PORT`
    - `HOST`
    - `CLAWDBOT_SERVICE`
    - `CLAWDBOT_PROCESS_PATTERNS`
- `docs/SETUP_SYSTEMD.md`
  - install script 経由で override を設定する方法を追記

## 使い方（例）
```bash
CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot ./scripts/install-systemd.sh
```

## 注意
override を生成しない場合は、従来どおり systemd unit のみをインストールします。
