### PR TITLE
ユーザー固有設定(.env.local)を導入し、installスクリプトでoverride生成まで自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
 .env
+config/.env.local
 .DS_Store

--- a/config/.env.example
+++ b/config/.env.example
@@ -1,0 +1,12 @@
+# Copy to config/.env.local (do not commit .env.local)
+
+# Server
+PORT=8080
+HOST=0.0.0.0
+
+# Health check (choose one approach)
+# 1) systemd unit check
+# CLAWDBOT_SERVICE=clawdbot-gateway
+
+# 2) process existence check (pgrep -f), comma-separated
+CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot

--- a/docs/SETUP_SYSTEMD.md
+++ b/docs/SETUP_SYSTEMD.md
@@ -15,17 +15,29 @@ sudo mkdir -p /opt/raspi-openclaw-ops
 sudo chown -R $USER:$USER /opt/raspi-openclaw-ops
 ```
 
-## 2) Install dependencies + build
+## 2) Install (recommended)
+
+### Use install script
+
+From your git working directory:
+
+```bash
+# optional: create a local config file
+cp config/.env.example config/.env.local
+
+# edit config/.env.local
+
+# deploy + build + install systemd + (optional) create overrides
+./scripts/install-systemd.sh
+```
+
+## 3) Manual (if needed)
 
 ```bash
 cd /opt/raspi-openclaw-ops
 npm ci --include=dev
 npm run build
-```
 
-## 3) Install systemd unit
-
-```bash
 sudo cp systemd/raspi-openclaw-ops.service /etc/systemd/system/raspi-openclaw-ops.service
 sudo systemctl daemon-reload
 sudo systemctl enable --now raspi-openclaw-ops
@@ -40,17 +52,27 @@ journalctl -u raspi-openclaw-ops -f
 
 ## 4) Configure Clawdbot health check (optional)
 
-### Option A: set overrides via install script (recommended)
+### Option A: set via `config/.env.local` (recommended)
 
-You can pass env vars when running the installer:
+Edit `config/.env.local` and set:
+
+```env
+CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
+```
+
+Then re-run:
+
+```bash
+./scripts/install-systemd.sh
+```
+
+You can also pass env vars inline:
 
 ```bash
 CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot ./scripts/install-systemd.sh
 ```
 
 ### Option B: set a systemd drop-in manually
-
-If Clawdbot is **not** managed by systemd, use process check:
 
 ```bash
 sudo systemctl edit raspi-openclaw-ops

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 APP_DIR=${APP_DIR:-/opt/raspi-openclaw-ops}
 SERVICE_NAME=${SERVICE_NAME:-raspi-openclaw-ops}
 
+# Optional: load local config (gitignored)
+# Default: config/.env.local
+DOTENV_FILE=${DOTENV_FILE:-config/.env.local}
+
 # Optional overrides for /etc/systemd/system/<service>.service.d/override.conf
 PORT=${PORT:-}
 HOST=${HOST:-}
@@ -13,6 +17,35 @@ CLAWDBOT_PROCESS_PATTERNS=${CLAWDBOT_PROCESS_PATTERNS:-}
 if [[ $EUID -eq 0 ]]; then
   echo "Do not run as root. Run as a normal user with sudo available." >&2
   exit 1
+fi
+
+# Safety: encourage running from a git working tree (prevents deploying random /opt contents).
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "ERROR: This script should be run from a git working tree (e.g. ~/src/raspi-openclaw-ops)." >&2
+  echo "       Current directory is not a git repo." >&2
+  echo "       If you really know what you're doing, set ALLOW_NO_GIT=1." >&2
+  if [[ "${ALLOW_NO_GIT:-}" != "1" ]]; then
+    exit 2
+  fi
+fi
+
+if [[ -f "${DOTENV_FILE}" ]]; then
+  echo "==> Loading dotenv: ${DOTENV_FILE}" >&2
+  # shellcheck disable=SC1090
+  set -a
+  source "${DOTENV_FILE}"
+  set +a
+fi
+
+# Re-read after dotenv
+PORT=${PORT:-}
+HOST=${HOST:-}
+CLAWDBOT_SERVICE=${CLAWDBOT_SERVICE:-}
+CLAWDBOT_PROCESS_PATTERNS=${CLAWDBOT_PROCESS_PATTERNS:-}
+
+if [[ -n "${CLAWDBOT_SERVICE}" && -n "${CLAWDBOT_PROCESS_PATTERNS}" ]]; then
+  echo "ERROR: Set only one of CLAWDBOT_SERVICE or CLAWDBOT_PROCESS_PATTERNS." >&2
+  exit 2
 fi
 
 echo "==> Installing to: ${APP_DIR}" >&2
@@ -53,10 +86,23 @@ if [[ -n "${PORT}" || -n "${HOST}" || -n "${CLAWDBOT_SERVICE}" || -n "${CLAWDBOT
 
   sudo cp "${tmpfile}" "${OVERRIDE_FILE}"
   rm -f "${tmpfile}"
+else
+  echo "==> No overrides provided; skipping drop-in generation" >&2
 fi
 
 sudo systemctl daemon-reload
 sudo systemctl enable --now "${SERVICE_NAME}"
+
+# Post-check
+echo "==> Verifying" >&2
+sudo systemctl --no-pager -l status "${SERVICE_NAME}" | sed -n '1,12p' >&2 || true
+
+CHECK_PORT=${PORT:-8080}
+if command -v curl >/dev/null 2>&1; then
+  echo "==> Checking health endpoint: http://127.0.0.1:${CHECK_PORT}/health.json" >&2
+  curl -fsS "http://127.0.0.1:${CHECK_PORT}/health.json" || true
+  echo >&2
+fi
 
 echo "==> Done" >&2
 echo "- Status: systemctl status ${SERVICE_NAME}" >&2


### PR DESCRIPTION
## 目的
ユーザー固有設定を `config/.env.local` にまとめ、スクリプト実行時に毎回オプションを打たなくても
systemd の override（drop-in）生成まで含めて完結できるようにする。

## 変更内容
- `config/.env.example` を追加
- `config/.env.local` を `.gitignore` に追加
- `scripts/install-systemd.sh`
  - `config/.env.local`（または `DOTENV_FILE`）を自動読み込み
  - 指定された値で `/etc/systemd/system/<service>.service.d/override.conf` を生成
  - 事故防止: git working tree 以外での実行をデフォルトで拒否（`ALLOW_NO_GIT=1` で回避）
  - インストール後に `health.json` を curl して簡易検証
- `docs/SETUP_SYSTEMD.md` を更新（.env.local で設定→スクリプト再実行の流れ）

## 使い方
```bash
cp config/.env.example config/.env.local
# config/.env.local を編集
./scripts/install-systemd.sh
```

例: `clawdbot-gateway` と `clawdbot` を監視
```env
CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
```
