### PR TITLE
CPU温度・ディスク使用率を表示し、しきい値でDEGRADEDにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Raspberry Pi 上で動く OpenClaw/Clawdbot の **運用(ops)** 用リポジト�
 - `GET /status.json` : 詳細 JSON
 
 現在の実装は以下を収集します：
-- ホスト情報 (uptime / load / memory / IP)
+- ホスト情報 (uptime / load / memory / CPU温度 / ディスク使用率 / IP)
 - （任意）systemd サービス状態（`CLAWDBOT_SERVICE` を設定した場合）
 
 ## Quick start (dev)

--- a/config/.env.example
+++ b/config/.env.example
@@ -10,3 +10,7 @@ HOST=0.0.0.0
 
 # 2) process existence check (pgrep -f), comma-separated
 CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
+
+# Thresholds
+CPU_TEMP_WARN_C=80
+DISK_USED_WARN_PCT=90


### PR DESCRIPTION
Closes #10

## 目的
運用で重要なメトリクス（CPU温度・ディスク使用率）をステータスページ/JSONに追加し、しきい値超過時に Health を `DEGRADED` にする。

## 変更内容
- CPU温度を取得して表示
  - 優先: `vcgencmd measure_temp`
  - フォールバック: `/sys/class/thermal/thermal_zone0/temp`
- `/` のディスク使用率を取得して表示（`df -P /`）
- しきい値（デフォルト）
  - `CPU_TEMP_WARN_C=80`
  - `DISK_USED_WARN_PCT=90`
  - 超過時は Notes に理由を追加し、Health を `DEGRADED`
- `config/.env.example` にしきい値を追加
- README の収集項目を更新

## 動作確認
- `npm run dev` で起動し、`/` と `/status.json` を確認
- 必要に応じて `CPU_TEMP_WARN_C` / `DISK_USED_WARN_PCT` を変更して挙動確認
