### PR TITLE
CPU使用率に移動平均(10秒)を追加する

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -359,13 +359,15 @@ function htmlPage(data: Awaited<ReturnType<typeof collectStatus>>) {
       <div class="card half">
         <p class="k">CPU usage</p>
         <p class="v">
-          ${data.host.cpuUsagePctInstant == null
+          <span style="font-weight:800">avg10s:</span>
+          ${data.host.cpuUsagePctAvg10s == null
             ? '<span style="color:var(--muted)">n/a</span>'
-            : `${data.host.cpuUsagePctInstant.toFixed(0)}/100`}
-          <span style="color:var(--muted);font-size:12px; margin-left:8px">(avg10s:
-            ${data.host.cpuUsagePctAvg10s == null ? 'n/a' : `${data.host.cpuUsagePctAvg10s.toFixed(0)}/100`})</span>
+            : `${data.host.cpuUsagePctAvg10s.toFixed(0)}%`}
         </p>
-        <div class="sub">Calculated from <code>/proc/stat</code> deltas (first request may be n/a)</div>
+        <div class="sub">
+          now: ${data.host.cpuUsagePctInstant == null ? 'n/a' : `${data.host.cpuUsagePctInstant.toFixed(0)}%`}
+          ・ calculated from <code>/proc/stat</code> deltas (first request may be n/a)
+        </div>
       </div>
 
       <div class="card half">


### PR DESCRIPTION
Closes #15

## 概要
CPU 使用率の表示に、瞬間値に加えて「直近10秒の移動平均」を併記します。

- 表示は `%` に統一
- 画面では **avg10s を主表示**（大きく）、瞬間値(now)は補助表示にします

## 変更内容
- `/proc/stat` 差分で算出した瞬間値をサンプルとして保持（最大60秒）
- 直近10秒のサンプル平均を `avg10s` として計算
- HTML:
  - `avg10s: N%` を主表示
  - `now: N%` を補助表示
- JSON:
  - `host.cpuUsagePctInstant`
  - `host.cpuUsagePctAvg10s`

## 注意
- 初回リクエストやサンプルが不足している場合は `n/a` になります。
