### PR TITLE
ステータスUIにトークン認証を追加する

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -14,3 +14,11 @@ CLAWDBOT_PROCESS_PATTERNS=clawdbot-gateway,clawdbot
 # Thresholds
 CPU_TEMP_WARN_C=80
 DISK_USED_WARN_PCT=90
+
+# Security (optional)
+# If set, all endpoints require token auth.
+# You can pass token via:
+# - query: ?token=...
+# - header: Authorization: Bearer ...
+# - header: X-Status-Token: ...
+STATUS_TOKEN=


### PR DESCRIPTION
Closes #19

## 概要
将来的に VPN/Tailscale 経由や外部から参照する可能性に備え、ステータスUI/JSONに「共有トークン認証」を追加します。

## 使い方
- `STATUS_TOKEN` を設定すると認証が有効化されます
- トークンの渡し方（いずれか）
  - Query: `?token=...`
  - Header: `Authorization: Bearer ...`
  - Header: `X-Status-Token: ...`

## 挙動
- `STATUS_TOKEN` 未設定 → 従来どおり無認証
- `STATUS_TOKEN` 設定 → 未認証は `401`

## 変更内容
- Fastify の `onRequest` hook で全エンドポイントを保護
- `config/.env.example` に `STATUS_TOKEN` を追記

## 動作確認
- `STATUS_TOKEN=abc npm run dev`
  - 未認証アクセス → 401
  - `?token=abc` でアクセス → 200

