### PR TITLE
DiscordにHealth状態変化を通知する

### DIFF
--- a/config/.env.example
+++ b/config/.env.example
@@ -22,3 +22,11 @@ DISK_USED_WARN_PCT=90
 # - header: Authorization: Bearer ...
 # - header: X-Status-Token: ...
 STATUS_TOKEN=
+
+# Discord notifications (optional)
+# Notify on Health state changes via a Discord webhook.
+DISCORD_WEBHOOK_URL=
+# Minimum interval between notifications (seconds)
+DISCORD_NOTIFY_MIN_INTERVAL_SEC=300
+# Public URL shown in notification (optional)
+PUBLIC_STATUS_URL=

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,0 +1,46 @@
+export type Health = 'ok' | 'degraded' | 'down';
+
+export type NotifyDecisionInput = {
+  prevHealth: Health | null;
+  nextHealth: Health;
+  nowMs: number;
+  lastNotifiedAtMs: number | null;
+  minIntervalMs: number;
+  // If true, we never notify when prevHealth is null (boot).
+  skipInitial: boolean;
+};
+
+export type NotifyDecision = {
+  shouldNotify: boolean;
+  reason: string;
+};
+
+export function decideNotify(input: NotifyDecisionInput): NotifyDecision {
+  const { prevHealth, nextHealth, nowMs, lastNotifiedAtMs, minIntervalMs, skipInitial } = input;
+
+  if (skipInitial && prevHealth == null) {
+    return { shouldNotify: false, reason: 'initial-skip' };
+  }
+
+  if (prevHealth === nextHealth) {
+    return { shouldNotify: false, reason: 'no-change' };
+  }
+
+  if (lastNotifiedAtMs != null && nowMs - lastNotifiedAtMs < minIntervalMs) {
+    return { shouldNotify: false, reason: 'rate-limited' };
+  }
+
+  return { shouldNotify: true, reason: 'state-changed' };
+}
+
+export async function postDiscordWebhook(webhookUrl: string, content: string) {
+  const r = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!r.ok) {
+    const text = await r.text().catch(() => '');
+    throw new Error(`Discord webhook failed: ${r.status} ${r.statusText} ${text}`);
+  }
+}

--- a/test/notify.test.ts
+++ b/test/notify.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { decideNotify } from '../src/notify.js';
+
+describe('decideNotify', () => {
+  it('skips initial when configured', () => {
+    const d = decideNotify({
+      prevHealth: null,
+      nextHealth: 'ok',
+      nowMs: 1000,
+      lastNotifiedAtMs: null,
+      minIntervalMs: 0,
+      skipInitial: true,
+    });
+    expect(d.shouldNotify).toBe(false);
+    expect(d.reason).toBe('initial-skip');
+  });
+
+  it('notifies on change', () => {
+    const d = decideNotify({
+      prevHealth: 'ok',
+      nextHealth: 'degraded',
+      nowMs: 1000,
+      lastNotifiedAtMs: null,
+      minIntervalMs: 0,
+      skipInitial: true,
+    });
+    expect(d.shouldNotify).toBe(true);
+  });
+
+  it('rate-limits', () => {
+    const d = decideNotify({
+      prevHealth: 'ok',
+      nextHealth: 'degraded',
+      nowMs: 10_000,
+      lastNotifiedAtMs: 9_000,
+      minIntervalMs: 5_000,
+      skipInitial: false,
+    });
+    expect(d.shouldNotify).toBe(false);
+    expect(d.reason).toBe('rate-limited');
+  });
+});


### PR DESCRIPTION
Closes #27

## 概要
Health の状態変化（OK/DEGRADED/DOWN）を Discord に通知します（Webhook）。

## 使い方
`config/.env.local` に設定：
```env
DISCORD_WEBHOOK_URL=... # Discord Webhook URL
DISCORD_NOTIFY_MIN_INTERVAL_SEC=300
PUBLIC_STATUS_URL=https://... # 任意
```

## 仕様
- `DISCORD_WEBHOOK_URL` が未設定の場合は通知しません
- 状態が変化したときのみ通知（起動直後の初回は通知しない）
- 連投抑制（デフォルト5分、`DISCORD_NOTIFY_MIN_INTERVAL_SEC`）

## 実装
- background sampler（既存）内で health state を監視
- `GET /metrics.json` 用のサンプル収集とは独立せず同じ周期で動作
- 通知判定ロジックは純関数化しユニットテスト追加

## テスト
- `npm test`
  - notify判定（初回スキップ、状態変化、rate-limit）

