### PR TITLE
v0.2.0 リリース準備（changelog / 手順 / version）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+このプロジェクトの変更履歴。
+
+## v0.2.0 (2026-02-08)
+
+### 追加
+- ステータスページ（HTML） + JSON エンドポイント（/health.json, /status.json）
+- CPU 使用率（瞬間値 + avg10s）、CPU 温度、ディスク使用率、メモリ使用率の表示
+- Summary / Metrics タブ切り替え + CPU usage グラフ（メモリ内履歴）
+- トークン認証（STATUS_TOKEN）
+- systemd インストール/デプロイ用スクリプト（.env.local 読み込み、EnvironmentFile 反映、restart/検証）
+- TDD 方針の明文化（CLAUDE.md） + テスト基盤（Vitest）
+
+### 変更
+- 表示時刻を JST（Asia/Tokyo）に変更（TIME_ZONE で上書き可能）
+
+### 注意
+- 履歴グラフのデータはメモリ内のみ（再起動で消えます）

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,31 @@
+# リリース手順
+
+このリポジトリでは GitHub Releases を使って運用上のバージョンを管理します。
+
+## 方針
+- バージョニング: SemVer（例: v0.2.0）
+- PR は Issue に紐づける（`Closes #...`）
+- リリースノートは日本語
+
+## 手順（例: v0.2.0）
+
+1) `CHANGELOG.md` を更新
+- vX.Y.Z のセクションを追加
+
+2) `package.json` の version を更新
+
+3) PR 作成 → レビュー → マージ
+
+4) タグ&リリース作成（gh）
+
+```bash
+# main が最新であることを確認
+
+gh release create vX.Y.Z \
+  --repo 1222-takeshi/raspi-openclaw-ops \
+  --title "vX.Y.Z" \
+  --notes-file /tmp/release_notes.md
+```
+
+## リリースノート
+- 基本は `CHANGELOG.md` の vX.Y.Z の内容を貼り付けます。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "raspi-openclaw-ops",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "raspi-openclaw-ops",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "fastify": "^5.7.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raspi-openclaw-ops",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Operations toolkit for Clawdbot running on Raspberry Pi (health/status UI, monitoring, and automation scripts).",
   "type": "module",


### PR DESCRIPTION
Closes #29

## 概要
v0.2.0 のリリース運用を開始し、初回リリースのための changelog / 手順 / version 更新を行います。

## 変更内容
- `CHANGELOG.md` を追加（v0.2.0 の変更内容を記載）
- `docs/RELEASE.md` を追加（リリース手順）
- `package.json` の version を 0.2.0 に更新

## 動作確認
- `npm test`

