### PR TITLE
稼働中のバージョン/ビルド情報を表示する

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,0 +1,16 @@
+export type BuildInfo = {
+  version: string;
+  gitRef: string | null;
+  gitSha: string | null;
+  buildTime: string | null;
+};
+
+type Env = Record<string, string | undefined>;
+
+export function getBuildInfo(env: Env, versionFromPackage: string): BuildInfo {
+  const version = (env.APP_VERSION ?? versionFromPackage ?? '').trim() || 'unknown';
+  const gitRef = (env.GIT_REF ?? '').trim() || null;
+  const gitSha = (env.GIT_SHA ?? '').trim() || null;
+  const buildTime = (env.BUILD_TIME ?? '').trim() || null;
+  return { version, gitRef, gitSha, buildTime };
+}

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getBuildInfo } from '../src/build.js';
+
+describe('getBuildInfo', () => {
+  it('uses package version when env not set', () => {
+    const b = getBuildInfo({}, '0.2.0');
+    expect(b.version).toBe('0.2.0');
+    expect(b.gitRef).toBeNull();
+  });
+
+  it('prefers APP_VERSION when set', () => {
+    const b = getBuildInfo({ APP_VERSION: '0.2.1' }, '0.2.0');
+    expect(b.version).toBe('0.2.1');
+  });
+
+  it('reads git fields', () => {
+    const b = getBuildInfo({ GIT_REF: 'v0.2.0', GIT_SHA: 'abc', BUILD_TIME: 't' }, '0.0.0');
+    expect(b.gitRef).toBe('v0.2.0');
+    expect(b.gitSha).toBe('abc');
+    expect(b.buildTime).toBe('t');
+  });
+});


### PR DESCRIPTION
Closes #31

## 概要
稼働中のバージョン/ビルド情報をステータスページと JSON に表示します。

## 表示/出力
- `version`（package.json）
- `gitRef`（例: v0.2.0 / main）
- `gitSha`（短縮 sha）
- `buildTime`

## 取得方法
- `version`: 実行環境の `package.json` を読み込み
- `gitRef/gitSha/buildTime`: install スクリプトが systemd EnvironmentFile に埋め込み

## 変更内容
- `/status.json` と `/health.json` に `build` を追加
- HTML のヘッダに `vX.Y.Z (ref @ sha)` を表示
- `scripts/install-systemd.sh` が `APP_VERSION/GIT_REF/GIT_SHA/BUILD_TIME` を envfile に書き込む
- build情報の組み立てロジックを純関数化しユニットテスト追加

## 動作確認
- `npm test`
- デプロイ後、画面に v0.2.0 等が表示されること

