### PR TITLE
運用ドキュメント（デプロイ/運用/トラブルシュート）を整備する

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ npm run dev
 
 ### Option A: systemd (recommended)
 
-See: `docs/SETUP_SYSTEMD.md`
+See:
+- `docs/SETUP_SYSTEMD.md`
+- `docs/DEPLOY.md`
+- `docs/OPERATIONS.md`
+- `docs/TROUBLESHOOTING.md`
 
 ### Option B: manual
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,61 @@
+# デプロイ手順
+
+このプロジェクトは `scripts/install-systemd.sh` を用いて `/opt/raspi-openclaw-ops` へデプロイし、systemd で常駐させます。
+
+## 前提
+- raspi に Node.js (>=22)
+- systemd
+
+## 初回セットアップ
+
+```bash
+# 作業ディレクトリ（git管理）
+mkdir -p ~/src
+cd ~/src
+git clone https://github.com/1222-takeshi/raspi-openclaw-ops.git
+cd raspi-openclaw-ops
+
+# ローカル設定（gitignore）
+cp -n config/.env.example config/.env.local
+nano config/.env.local
+
+# デプロイ
+./scripts/install-systemd.sh
+```
+
+## リリース（タグ）を指定してデプロイ
+
+```bash
+cd ~/src/raspi-openclaw-ops
+git fetch --tags
+git checkout v0.2.0
+./scripts/install-systemd.sh
+```
+
+## 更新（main）
+
+```bash
+cd ~/src/raspi-openclaw-ops
+git checkout main
+git pull
+./scripts/install-systemd.sh
+```
+
+## ロールバック
+
+```bash
+cd ~/src/raspi-openclaw-ops
+git fetch --tags
+git checkout v0.2.0   # 戻したいタグ
+./scripts/install-systemd.sh
+```
+
+## 確認
+
+```bash
+systemctl status raspi-openclaw-ops
+journalctl -u raspi-openclaw-ops -f
+
+# token を使う場合
+curl -i "http://127.0.0.1:8080/health.json?token=YOUR_TOKEN"
+```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,38 @@
+# 運用（Operations）
+
+## 日常チェック
+
+- サービス状態
+
+```bash
+systemctl status raspi-openclaw-ops
+journalctl -u raspi-openclaw-ops -n 100 --no-pager
+```
+
+- ヘルス確認
+
+```bash
+curl -i "http://127.0.0.1:8080/health.json?token=YOUR_TOKEN"
+```
+
+## 設定（config/.env.local）
+
+ローカル設定は `config/.env.local` にまとめます（gitignore）。
+
+主な項目：
+- `STATUS_TOKEN`：トークン認証
+- `CLAWDBOT_PROCESS_PATTERNS`：監視対象プロセス
+- `METRICS_DB_PATH`：SQLite保存先
+- `METRICS_RAW_RETENTION_HOURS` / `METRICS_1M_RETENTION_DAYS`：保持期間
+- `CPU_TEMP_WARN_C` / `DISK_USED_WARN_PCT` / `INODE_USED_WARN_PCT`：しきい値
+- `DMESG_SCAN_ENABLED` / `DMESG_MAX_LINES`：dmesgスキャン
+
+## データ（SQLite）
+
+- デフォルト: `/opt/raspi-openclaw-ops/data/metrics.db`
+- raw（高頻度）と 1m（ロールアップ）を保持し、一定間隔で prune します。
+
+## バージョン確認
+
+画面上部と `/status.json` に build 情報（version/ref/sha/time）が出ます。
+「反映されてない？」と思ったらここを見るのが最速です。

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,59 @@
+# トラブルシューティング
+
+## 画面が変わらない / 最新が反映されない
+
+1) どのバージョンが動いているか確認
+- 画面上部の build 情報
+- `/status.json` の `build`
+
+2) systemd 再起動
+```bash
+sudo systemctl restart raspi-openclaw-ops
+sudo systemctl status raspi-openclaw-ops --no-pager -l
+```
+
+3) デプロイ対象が main / tag か確認
+```bash
+cd ~/src/raspi-openclaw-ops
+git status -sb
+git describe --tags --always
+```
+
+## EADDRINUSE: address already in use
+
+8080 を別プロセスが使っています。
+
+```bash
+sudo ss -ltnp | grep :8080
+sudo lsof -i :8080
+```
+
+systemd 側を止める/ポート変更（`PORT=...`）で回避。
+
+## 401 Unauthorized になる
+
+トークン認証が有効です。
+
+- URLに `?token=...`
+- もしくは Header: `Authorization: Bearer ...`
+
+systemd の envfile が更新されているか確認：
+```bash
+sudo systemctl show raspi-openclaw-ops -p EnvironmentFile
+sudo systemctl cat raspi-openclaw-ops
+```
+
+## SQLite のエラー（DBディレクトリ/権限）
+
+- デフォルト: `/opt/raspi-openclaw-ops/data/metrics.db`
+- ディレクトリ権限を確認
+
+```bash
+ls -ld /opt/raspi-openclaw-ops /opt/raspi-openclaw-ops/data
+ls -l /opt/raspi-openclaw-ops/data
+```
+
+## dmesg が読めない
+
+環境によっては権限で読めません。
+- `DMESG_SCAN_ENABLED=0` で無効化できます。


### PR DESCRIPTION
Closes #38

## 概要
運用に必要なドキュメント（デプロイ/運用/トラブルシュート）を追加し、READMEから辿れるようにします。

## 追加
- `docs/DEPLOY.md`
  - 初回セットアップ
  - リリースタグ指定デプロイ
  - 更新/ロールバック
- `docs/OPERATIONS.md`
  - 日常チェック
  - `.env.local` の主な設定
  - SQLiteデータと保持
  - バージョン確認
- `docs/TROUBLESHOOTING.md`
  - 反映されない
  - EADDRINUSE
  - 401
  - SQLite/権限
  - dmesg

## 変更
- README: 上記ドキュメントへのリンクを追加

